### PR TITLE
Add v as the prefix of the image tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,9 @@ jobs:
           type=schedule
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern=v{{version}}
+          type=semver,pattern=v{{major}}.{{minor}}
+          type=semver,pattern=v{{major}}
           type=sha
     - name: Docker meta for Contributors
       id: metaContributors
@@ -42,9 +42,9 @@ jobs:
           type=schedule
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
+          type=semver,pattern=v{{version}}
+          type=semver,pattern=v{{major}}.{{minor}}
+          type=semver,pattern=v{{major}}
           type=sha
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
As you can see below:

![image](https://user-images.githubusercontent.com/1450685/119312253-b60e9700-bca4-11eb-9f56-a0bbe77017d9.png)

All image tag names start with `vx.x.x`. We should follow the same pattern instead of creating a new one.

Desired reviewer @JohnNiang 